### PR TITLE
Add currentPageNumber to context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ export const prismicPagination = async (args: {
           previousPagePath:
             i > 1 ? `${args.pathPrefix}/${i}` : `${args.pathPrefix}`,
         }),
+        currentPageNumber: i + 1,
         ...args.prismicConnectionArgs,
       },
     })


### PR DESCRIPTION
Useful for rendering on the page what page number the user is currently looking at.  As far as I can tell, without this change, it would need to be reverse engineered from `pageContext.slug`?